### PR TITLE
Add mikoi_execute resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,31 +66,58 @@ Attributes
 
 Usage
 -----
-#### mikoi::default
+### mikoi::default
 Installs mikoi go package.
 
 Just include `mikoi` in your node's `run_list`:
 
 ```json
 {
-  "name":"my_node",
+  "name": "my_node",
   "run_list": [
     "recipe[mikoi]"
   ]
 }
 ```
 
-#### Resource
-Use the custom resource `mikoi_proxy` to wrap other resources to be run while
-the proxy is running.
+Resources
+---------
+
+### mikoi_execute
+Run a command through mikoi. Make sure your command has at least one port placeholder (`{}`).
 
 ```ruby
-mikoi_proxy 'name' do
-  block do
-    execute %q(curl 'localhost:{port}')
-  end
+mikoi_execute 'name' do
+  command %q(curl -H 'Host: example.com' 'localhost:{}/status')
+  hostname 'example.com'
+  port 80
+  proxy_protocol true
 end
 ```
+
+#### Actions
+Action | Description | Default
+------ |------------ |--------
+run    | Run command | Yes
+
+#### Attributes
+
+Attribute       | Description | Type | Default
+---------       |------------ |----- |--------
+hostname        | The hostname for mikoi to connect to | String
+port            | The hostname for mikoi to connect to | String, Integer
+proxy_timeout   | The timeout for mikoi, including units as understood by Go [`time.Duration`](https://golang.org/pkg/time/#Duration) | String | `10s`
+proxy_protocol  | Use Proxy Protocol | Boolean | `false`
+verbose         | Make mikoi verbose | Boolean | `false`
+command         | The command to be executed. Must contain at least one placeholder `{}` for the ephemeral port | String, Array | (name attribute)
+creates         | Prevent command from running if this file exists | String |
+cwd             | The current working directory from which a command is run. | String |
+environment     | A hash of environment variables. | Hash
+group           | The group name or group ID that must be changed before running a command | String, Integer
+returns         | The return value for a command. This may be an array of accepted values. An exception is raised when the return value(s) do not match | Integer, Array
+command_timeout | The amount of time (in seconds) a command will wait before timing out | Integer
+user            | The user name or user ID that should be changed before running a command | String, Integer
+umask           | The file mode creation mask, or umask | String, Integer
 
 Testing
 -------

--- a/README.md
+++ b/README.md
@@ -1,14 +1,26 @@
 mikoi Cookbook
-============================
+==============
 Use [mikoi](https://github.com/nabeken/mikoi) to enable making requests to a server with [HAProxy's Proxy Protocol](http://www.haproxy.org/download/1.5/doc/proxy-protocol.txt).
 
 Requirements
 ------------
-TODO: List your cookbook requirements. Be sure to include any requirements this cookbook has on platforms, libraries, other cookbooks, packages, operating systems, etc.
 
-e.g.
+#### Chef
+Tested with 11.16.4.
+Should work with Chef 12
+
 #### cookbooks
-- `golang` - installs go programming language
+- `golang` - installs go programming language (only needed for `['mikoi']['install_method'] == 'go'`)
+
+#### Platform
+Tested on Ubuntu 14.04. Other linux distributions should all work out of the box.
+
+Working on freebsd except for go install (as not supported by [golang cookbook](https://github.com/NOX73/chef-golang))
+
+Windows and Mac OS X versions of mikoi have been included but no promises made as to whether they will work. For Windows you will likely need to set `['mikoi']['install_dir']`
+
+#### Ruby
+MRI Ruby >= 1.9
 
 Attributes
 ----------
@@ -27,7 +39,7 @@ Attributes
     <td>Install method:
       <ol>
         <li><tt>release</tt> to install from binary release</li>
-        <li><tt>go</tt> to install using <tt>go get</tt></li>
+        <li><tt>go</tt> to install using Go</li>
       </ol>
     </td>
     <td><tt>release</tt></td>

--- a/README.md
+++ b/README.md
@@ -133,7 +133,43 @@ umask           | The file mode creation mask, or umask | String, Integer
 
 Testing
 -------
-This project uses foodcritic and chefspec, both of which can be run through guard. Integration tests use kitchen.
+### Unit tests and lint
+This project uses foodcritic and chefspec, both of which can be run through guard.
+
+Please check for resource coverage by setting `COVERAGE` env variable, e.g.:
+
+```sh
+COVERAGE=true bundle exec guard
+```
+### Integration tests
+Integration tests use test-kitchen. Follow the [getting started guide](http://kitchen.ci/docs/getting-started/)
+
+Brief sample usage:
+
+```sh
+# Help
+bundle exec kitchen help
+
+# List all available test suites / platform variations
+bundle exec kitchen list
+
+# Test (destroy, converge and verify) without destroying after testing
+bundle exec kitchen test -d never release-ubuntu-*
+
+# manually inspect state of machine
+bundle exec kitchen login release-ubuntu-*
+
+# re-converge and verify
+bundle exec kitchen converge release-ubuntu-* && \
+  bundle exec kitchen verify release-ubuntu-*
+
+# destroy when you are done
+bundle exec kitchen destroy
+```
+
+#### Debugging
+
+Debugging custom resources seems to be impossible using chef-shell in solo mode. Instead, use chef-shell in client mode with chef-zero as per [this script](https://gist.github.com/biinari/41ddc6eced8f1c42c00a7b0c98b9e868). Provide the run list as first argument to the script or set RUNLIST variable and copy/paste the commands from `cd /tmp/kitchen/` onwards.
 
 Contributing
 ------------

--- a/README.md
+++ b/README.md
@@ -76,6 +76,31 @@ Attributes
   </tr>
 </table>
 
+#### mikoi::execute
+Add a Hash of attributes supported by `mikoi_execute` resource for as many as you want to run (they will be looped through in one run). For example (see below for full list of attributes supported by `mikoi_execute`):
+
+```json
+{
+  "name": "my_node",
+  "run_list": [
+    "recipe[mikoi]",
+    "recipe[mikoi::execute]"
+  ],
+  "mikoi": {
+    "execute": {
+      "my_command": {
+        "hostname": "example.com",
+        "port": "8080",
+        "proxy_protocol": true,
+        "command": "curl -f -H 'Host: example.com' localhost:{}/test"
+      }
+    }
+  }
+}
+```
+
+For more freedom, use the `mikoi_execute` resource directly.
+
 Usage
 -----
 ### mikoi::default

--- a/README.md
+++ b/README.md
@@ -141,8 +141,8 @@ run    | Run command | Yes
 
 Attribute       | Description | Type | Default
 ---------       |------------ |----- |--------
-hostname        | The hostname for mikoi to connect to | String
-port            | The hostname for mikoi to connect to | String, Integer
+hostname        | The hostname for mikoi to connect to *(Required)* | String
+port            | The hostname for mikoi to connect to *(Required)* | String, Integer
 proxy_timeout   | The timeout for mikoi, including units as understood by Go [`time.Duration`](https://golang.org/pkg/time/#Duration) | String | `10s`
 proxy_protocol  | Use Proxy Protocol | Boolean | `false`
 verbose         | Make mikoi verbose | Boolean | `false`

--- a/attributes/execute.rb
+++ b/attributes/execute.rb
@@ -1,0 +1,1 @@
+default.mikoi.execute = {}

--- a/circle.yml
+++ b/circle.yml
@@ -15,5 +15,5 @@ database:
 
 test:
   override:
-    - bundle exec foodcritic --progress .
+    - bundle exec foodcritic -f any --progress .
     - bundle exec rspec --colour --require rspec_junit_formatter --require spec_helper --format documentation --format RspecJunitFormatter --out $CIRCLE_TEST_REPORTS/rspec/junit.xml spec

--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -1,0 +1,5 @@
+if defined?(ChefSpec)
+  def run_mikoi_execute(command)
+    ChefSpec::Matchers::ResourceMatcher.new(:mikoi_execute, :run, command)
+  end
+end

--- a/providers/execute.rb
+++ b/providers/execute.rb
@@ -1,0 +1,37 @@
+require 'shellwords'
+
+def whyrun_supported?
+  true
+end
+
+use_inline_resources
+
+action :run do
+  inline_execute = execute new_resource.name do
+    command mikoi_command
+    creates new_resource.creates
+    cwd new_resource.cwd
+    environment new_resource.environment
+    group new_resource.group
+    returns new_resource.returns
+    timeout new_resource.command_timeout
+    user new_resource.user
+    umask new_resource.umask
+  end
+
+  new_resource.updated_by_last_action(inline_execute.updated_by_last_action?)
+end
+
+private
+
+def mikoi
+  File.join(install_dir, 'mikoi')
+end
+
+def mikoi_command
+  cmd = "#{mikoi} --hostname=#{new_resource.hostname.shellescape} " \
+    "--port=#{new_resource.port.to_s.shellescape} "
+  cmd << '--proxyproto ' if new_resource.proxy_protocol
+  cmd << '--verbose ' if new_resource.verbose
+  cmd << "-- #{new_resource.command}"
+end

--- a/providers/execute.rb
+++ b/providers/execute.rb
@@ -6,9 +6,23 @@ end
 
 use_inline_resources
 
+def execute_command
+  case new_resource.command
+  when Array
+    case new_resource.command.first
+    when Array
+      array_with_argv0_command
+    when String
+      array_command
+    end
+  when String
+    string_command
+  end
+end
+
 action :run do
-  inline_execute = execute new_resource.name do
-    command mikoi_command
+  inline_execute = execute "mikoi_execute inline #{new_resource.name}" do
+    command execute_command
     creates new_resource.creates
     cwd new_resource.cwd
     environment new_resource.environment
@@ -25,13 +39,30 @@ end
 private
 
 def mikoi
-  File.join(install_dir, 'mikoi')
+  ::File.join(node.mikoi.install_dir, 'mikoi')
 end
 
 def mikoi_command
-  cmd = "#{mikoi} --hostname=#{new_resource.hostname.shellescape} " \
-    "--port=#{new_resource.port.to_s.shellescape} "
-  cmd << '--proxyproto ' if new_resource.proxy_protocol
-  cmd << '--verbose ' if new_resource.verbose
-  cmd << "-- #{new_resource.command}"
+  cmd = [mikoi]
+  cmd << '--hostname' << new_resource.hostname
+  cmd << '--port' << new_resource.port.to_s
+  cmd << '--proxyproto' if new_resource.proxy_protocol
+  cmd << '--verbose' if new_resource.verbose
+  cmd << '--'
+end
+
+def string_command
+  mikoi_command.map(&:shellescape).join(' ') + ' ' + new_resource.command
+end
+
+def array_command
+  mikoi_command + new_resource.command
+end
+
+def array_with_argv0_command
+  cmd = [[mikoi_command.first, new_resource.command.first.last]]
+  cmd += mikoi_command.drop(1)
+  cmd << new_resource.command.first.first
+  cmd += new_resource.command.drop(1)
+  cmd
 end

--- a/recipes/execute.rb
+++ b/recipes/execute.rb
@@ -1,0 +1,26 @@
+# Runs mikoi_execute resource for each item in node.mikoi.execute
+
+supported_attributes = %w(
+  hostname
+  port
+  proxy_timeout
+  proxy_protocol
+  verbose
+  command
+  creates
+  cwd
+  environment
+  group
+  returns
+  command_timeout
+  umask
+  user
+).freeze
+
+node.mikoi.execute.each do |name, attributes|
+  mikoi_execute name do
+    supported_attributes.each do |att_name|
+      send(att_name, attributes[att_name]) if attributes.key?(att_name)
+    end
+  end
+end

--- a/recipes/go.rb
+++ b/recipes/go.rb
@@ -6,3 +6,7 @@
 include_recipe 'golang'
 
 golang_package 'github.com/nabeken/mikoi'
+
+link File.join(node.mikoi.install_dir, 'mikoi') do
+  to File.join(node.go.gobin, 'mikoi')
+end

--- a/resources/execute.rb
+++ b/resources/execute.rb
@@ -1,0 +1,20 @@
+actions :run
+default_action :run
+
+# Mikoi attributes
+attribute :hostname, kind_of: String
+attribute :port, kind_of: [String, Integer]
+attribute :proxy_timeout, kind_of: String, default: '10s'
+attribute :proxy_protocol, kind_of: [TrueClass, FalseClass], default: false
+attribute :verbose, kind_of: [TrueClass, FalseClass], default: false
+
+# Execute attributes
+attribute :command, kind_of: [String, Array], name_attribute: true
+attribute :creates, kind_of: String
+attribute :cwd, kind_of: String
+attribute :environment, kind_of: Hash
+attribute :group, kind_of: [String, Integer]
+attribute :returns, kind_of: [Integer, Array]
+attribute :command_timeout, kind_of: Integer
+attribute :umask, kind_of: [String, Integer]
+attribute :user, kind_of: [String, Integer]

--- a/resources/execute.rb
+++ b/resources/execute.rb
@@ -4,7 +4,7 @@ default_action :run
 # Mikoi attributes
 attribute :hostname, kind_of: String
 attribute :port, kind_of: [String, Integer]
-attribute :proxy_timeout, kind_of: String, default: '10s'
+attribute :proxy_timeout, kind_of: String
 attribute :proxy_protocol, kind_of: [TrueClass, FalseClass], default: false
 attribute :verbose, kind_of: [TrueClass, FalseClass], default: false
 

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -1,8 +1,15 @@
 describe 'mikoi::default' do
   context 'with release install method' do
+    let(:file_cache_path) { '/var/chef/cache' }
+    let(:mikoi_version) { 'arbitrary_version' }
     let(:chef_run) do
-      ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '14.04') do |node|
+      ChefSpec::SoloRunner.new(
+        platform: 'ubuntu',
+        version: '14.04',
+        file_cache_path: file_cache_path
+      ) do |node|
         node.set.mikoi.install_method = 'release'
+        node.set.mikoi.version = mikoi_version
       end.converge(described_recipe)
     end
 

--- a/spec/execute_spec.rb
+++ b/spec/execute_spec.rb
@@ -1,0 +1,112 @@
+describe 'mikoi::execute' do
+  let(:hostname) { '10.0.2.2' }
+  let(:port) { '8080' }
+  let(:proxy_protocol) { true }
+  let(:install_dir) { '/usr/local/bin' }
+  let(:mikoi) { File.join(install_dir, 'mikoi') }
+  let(:execute_attributes) do
+    {
+      name => {
+        hostname: hostname,
+        port: port,
+        proxy_protocol: proxy_protocol,
+        command: curl_command
+      }
+    }
+  end
+
+  let(:chef_run) do
+    ChefSpec::SoloRunner.new(step_into: ['mikoi_execute']) do |node|
+      node.set.mikoi.install_dir = install_dir
+      node.set.mikoi.execute = execute_attributes
+    end.converge(described_recipe)
+  end
+  subject { cached_run }
+
+  shared_examples 'runs mikoi_execute' do
+    it do
+      is_expected.to run_mikoi_execute(name)
+        .with_hostname(hostname)
+        .with_port(port)
+        .with_proxy_protocol(proxy_protocol)
+        .with_command(curl_command)
+    end
+
+    it 'runs the inline execute' do
+      is_expected.to run_execute("mikoi_execute inline #{name}")
+        .with_command(inline_command)
+    end
+  end
+
+  context 'with string command' do
+    let(:mikoi_command) do
+      "#{mikoi} --hostname #{hostname} --port #{port} --proxyproto --"
+    end
+    let(:curl_command) do
+      %(curl -f -s -H 'Host: example.com' 'localhost:{}/test')
+    end
+    let(:inline_command) do
+      "#{mikoi_command} #{curl_command}"
+    end
+    let(:name) { 'test with string command' }
+
+    cached(:cached_run) { chef_run }
+
+    include_examples 'runs mikoi_execute'
+  end
+
+  context 'with array command' do
+    let(:mikoi_command) do
+      [
+        mikoi,
+        '--hostname', hostname,
+        '--port', port,
+        '--proxyproto',
+        '--'
+      ]
+    end
+    let(:curl_command) do
+      [
+        'curl',
+        '-f', '-s',
+        '-H', 'Host: example.com',
+        'localhost:{}/test'
+      ]
+    end
+    let(:inline_command) { mikoi_command + curl_command }
+    let(:name) { 'test with array command' }
+
+    cached(:cached_run) { chef_run }
+
+    include_examples 'runs mikoi_execute'
+  end
+
+  context 'with array command including explicit argv0' do
+    let(:curl_command) do
+      [
+        ['curl', 'curl test argv0'],
+        '-f', '-s',
+        '-H', 'Host: example.com',
+        'localhost:{}/test'
+      ]
+    end
+    let(:inline_command) do
+      [
+        [mikoi, 'curl test argv0'],
+        '--hostname', hostname,
+        '--port', port,
+        '--proxyproto',
+        '--',
+        'curl',
+        '-f', '-s',
+        '-H', 'Host: example.com',
+        'localhost:{}/test'
+      ]
+    end
+    let(:name) { 'test with array command including explicit argv0' }
+
+    cached(:cached_run) { chef_run }
+
+    include_examples 'runs mikoi_execute'
+  end
+end

--- a/spec/go_spec.rb
+++ b/spec/go_spec.rb
@@ -16,4 +16,9 @@ describe 'mikoi::go' do
   it { is_expected.to include_recipe('golang') }
 
   it { is_expected.to install_golang_package('github.com/nabeken/mikoi') }
+
+  it do
+    is_expected.to create_link('/usr/local/bin/mikoi')
+      .with_to('/opt/go/bin/mikoi')
+  end
 end

--- a/test/integration/go/serverspec/localhost/go_spec.rb
+++ b/test/integration/go/serverspec/localhost/go_spec.rb
@@ -3,9 +3,15 @@ require 'spec_helper'
 describe 'go install method' do
   let(:file_cache_path) { '/tmp/kitchen/cache' }
   let(:go_bin_path) { '/opt/go/bin' }
+  let(:install_dir) { '/usr/local/bin' }
 
-  describe 'mikoi binary' do
+  describe 'mikoi go binary' do
     subject { file(File.join(go_bin_path, 'mikoi')) }
+    it { is_expected.to be_executable }
+  end
+
+  describe 'mikoi local binary' do
+    subject { file(File.join(install_dir, 'mikoi')) }
     it { is_expected.to be_executable }
   end
 end


### PR DESCRIPTION
Run a command through mikoi to enable connecting with proxy_protocol.

Sample usage (see README.md for more info):

``` ruby
mikoi_execute 'check app status' do
  command %q(curl -f -H 'Host: app.example.com' 'localhost:{}/status')
  hostname 'app.example.com'
  port '80'
  proxy_protocol true
end
```
